### PR TITLE
[FIX] Object Pool Spawn

### DIFF
--- a/Clase - State/Assets/Scripts/BulletMovement.cs
+++ b/Clase - State/Assets/Scripts/BulletMovement.cs
@@ -6,10 +6,10 @@ using UnityEngine.Pool;
 public class BulletMovement : MonoBehaviour
 {
     [SerializeField] private float speed;
-    [SerializeField] private float destroyTime;
+    [SerializeField] private float destroyTime = 2.0f;
     public ObjectPool<BulletMovement> pool;
 
-    private void Start()
+    private void OnEnable()
     {
         Invoke("BulletDestroy", destroyTime);
     }

--- a/Clase - State/Assets/Scripts/Player/Weapon.cs
+++ b/Clase - State/Assets/Scripts/Player/Weapon.cs
@@ -13,7 +13,7 @@ public class Weapon : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        bulletPool = new ObjectPool<BulletMovement>(CreateBullet,GetBullet,ReleaseBullet,DestroyBullet, false,10,15);
+        bulletPool = new ObjectPool<BulletMovement>(CreateBullet,GetBullet,ReleaseBullet,DestroyBullet, false,10,100);
 
         //for (int i = 0;i <10; i++)
         //{


### PR DESCRIPTION
* Modified the invoke from Start to OnEnable to avoid duplicating instances after they were started. The event was not invoking once we enabled them twice.